### PR TITLE
🐞 fix(): memory leak issue with dinosaur logo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-tetris",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/app/components/logo/logo.component.ts
+++ b/src/app/components/logo/logo.component.ts
@@ -1,7 +1,9 @@
 import { Component, OnInit } from '@angular/core';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { concat, Observable, timer } from 'rxjs';
 import { delay, finalize, map, repeat, startWith, takeWhile, tap } from 'rxjs/operators';
 
+@UntilDestroy()
 @Component({
   selector: 't-logo',
   templateUrl: './logo.component.html',
@@ -9,13 +11,16 @@ import { delay, finalize, map, repeat, startWith, takeWhile, tap } from 'rxjs/op
 })
 export class LogoComponent implements OnInit {
   className: string = '';
-  constructor() {}
+
+  constructor() {
+  }
 
   ngOnInit(): void {
     concat(this.run(), this.eyes())
       .pipe(
         delay(5000),
-        repeat(1000)
+        repeat(1000),
+        untilDestroyed(this)
       )
       .subscribe();
   }
@@ -27,7 +32,7 @@ export class LogoComponent implements OnInit {
       takeWhile((x) => x < 6),
       tap((x) => {
         let state = x % 2 === 0 ? 1 : 2;
-        this.className = `l${state}`;
+        this.className = `l${ state }`;
       })
     );
   }
@@ -43,10 +48,10 @@ export class LogoComponent implements OnInit {
           side = side === 'r' ? 'l' : 'r';
         }
         let state = x % 2 === 0 ? 3 : 4;
-        this.className = `${side}${state}`;
+        this.className = `${ side }${ state }`;
       }),
       finalize(() => {
-        this.className = `${side}1`;
+        this.className = `${ side }1`;
       })
     );
   }


### PR DESCRIPTION
There is a memory-leak with the subscription in `logo.component.ts` that handles the Dino animation.

https://share.getcloudapp.com/NQug82yJ Here's the clip of the memory leak issue. When the `LogoComponent` gets destroyed (because of `*ngIf`), the animation subscription still goes on. 

There are two ways of fixing this issue:
1. Unsubscribe the subscription on destroy
2. Use `[hidden]` instead of `*ngIf`. 

I went with the first option to adhere to Angular's concept more by sticking with `*ngIf` (for dynamically rendering on template) and utilize `untilDestroy` to demonstrate good practices in subscription handling.